### PR TITLE
fix: allow basic auth header overwrites

### DIFF
--- a/github-sync.sh
+++ b/github-sync.sh
@@ -23,7 +23,7 @@ fi
 echo "UPSTREAM_REPO=$UPSTREAM_REPO"
 echo "BRANCHES=$BRANCH_MAPPING"
 
-# GitHub actions v2 no longer auto set GITHUB_TOKEN
+git config --unset-all http."https://github.com/".extraheader
 git remote set-url origin "https://$GITHUB_ACTOR:$GITHUB_TOKEN@github.com/$GITHUB_REPOSITORY"
 git remote add tmp_upstream "$UPSTREAM_REPO"
 git fetch tmp_upstream


### PR DESCRIPTION
GitHub Checkout Action automatically set basic auth header overwriting access tokens supplied in HTTPS clone urls.

```
# .git/config

[core]
	repositoryformatversion = 0
	filemode = true
	bare = false
	logallrefupdates = true
[remote "origin"]
	url = https://github.com/repo-sync/private-destination-repo
	fetch = +refs/heads/*:refs/remotes/origin/*
[gc]
	auto = 0
[http "https://github.com/"]
	extraheader = AUTHORIZATION: basic ***
[branch "master"]
	remote = origin
	merge = refs/heads/master
```

This PR uses git command to delete these two lines:
```
[http "https://github.com/"]
	extraheader = AUTHORIZATION: basic ***
```

Fix #18

We can test the fix with `repo-sync/github-sync@fix-private-source-with-pat`

