### PR TITLE
Stop remap of upstream to github.com if it's a glitch.com repo

### DIFF
--- a/github-sync.sh
+++ b/github-sync.sh
@@ -15,7 +15,9 @@ if [[ -z "$BRANCH_MAPPING" ]]; then
   exit 1
 fi
 
-if ! echo $UPSTREAM_REPO | grep '\.git'
+# If the upstream repo does not have a ".git" suffix, we assume it's a shorthand for a github.com Username/Repo
+# However, this is ignored if the repo belongs to glitch.com and this allows us to use github as a backup repo 
+if [ ! $(echo $UPSTREAM_REPO | grep '\.git') ] && [ ! $(echo $UPSTREAM_REPO | grep 'api\.glitch\.com\/git\/') ]
 then
   UPSTREAM_REPO="https://github.com/${UPSTREAM_REPO}.git"
 fi


### PR DESCRIPTION
This allows the user to use this action to pull a glitch.com repo to GitHub as they too do not use the .git suffix :+1: