### PR TITLE
Update github-sync.sh

### DIFF
--- a/github-sync.sh
+++ b/github-sync.sh
@@ -39,7 +39,7 @@ git fetch tmp_upstream --quiet
 git remote --verbose
 
 echo "Pushing changings from tmp_upstream to origin"
-git push origin "refs/remotes/tmp_upstream/${BRANCH_MAPPING%%:*}:refs/heads/${BRANCH_MAPPING#*:}" --force
+git push origin "refs/remotes/tmp_upstream/${BRANCH_MAPPING%%:*}:refs/heads/${BRANCH_MAPPING#*:}" --force --no-verify
 
 if [[ "$SYNC_TAGS" = true ]]; then
   echo "Force syncing all tags"


### PR DESCRIPTION
Looks like with Git LFS turned on for docs, repo-sync stopped working, so I think we'll to skip the hook for repo-sync