### PR TITLE
[Draft] Make git force push as optional

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,9 +3,9 @@ FROM alpine
 LABEL \
   org.opencontainers.image.title="GitHub Repo Sync" \
   org.opencontainers.image.description="⤵️ A GitHub Action for syncing current repository with remote" \
-  org.opencontainers.image.url="https://github.com/repo-sync/github-sync" \
+  org.opencontainers.image.url="https://github.com/gomisha/github-sync" \
   org.opencontainers.image.documentation="https://github.com/marketplace/actions/github-sync" \
-  org.opencontainers.image.source="https://github.com/repo-sync/github-sync" \
+  org.opencontainers.image.source="https://github.com/gomisha/github-sync" \
   org.opencontainers.image.licenses="MIT" \
   org.opencontainers.image.authors="Wei He <github@weispot.com>" \
   maintainer="Wei He <github@weispot.com>"

--- a/action.yml
+++ b/action.yml
@@ -22,7 +22,7 @@ inputs:
     required: false
 runs:
   using: 'docker'
-  image: docker://ghcr.io/repo-sync/github-sync:v2.3.1
+  image: docker://ghcr.io/gomisha/github-sync:v2.3.1
   env:
     GITHUB_TOKEN: ${{ inputs.github_token }}
     SYNC_TAGS: ${{ inputs.sync_tags }}

--- a/action.yml
+++ b/action.yml
@@ -22,7 +22,7 @@ inputs:
     required: false
 runs:
   using: 'docker'
-  image: docker://ghcr.io/repo-sync/github-sync:v2.3.0
+  image: docker://ghcr.io/gomisha/github-sync:v2.3.1
   env:
     GITHUB_TOKEN: ${{ inputs.github_token }}
     SYNC_TAGS: ${{ inputs.sync_tags }}

--- a/action.yml
+++ b/action.yml
@@ -22,7 +22,7 @@ inputs:
     required: false
 runs:
   using: 'docker'
-  image: docker://ghcr.io/repo-sync/github-sync:v2.3.3
+  image: docker://ghcr.io/repo-sync/github-sync:v2.3.1
   env:
     GITHUB_TOKEN: ${{ inputs.github_token }}
     SYNC_TAGS: ${{ inputs.sync_tags }}

--- a/action.yml
+++ b/action.yml
@@ -22,7 +22,7 @@ inputs:
     required: false
 runs:
   using: 'docker'
-  image: docker://ghcr.io/gomisha/github-sync:v2.3.1
+  image: docker://ghcr.io/gomisha/github-sync:v2.3.2
   env:
     GITHUB_TOKEN: ${{ inputs.github_token }}
     SYNC_TAGS: ${{ inputs.sync_tags }}

--- a/action.yml
+++ b/action.yml
@@ -22,7 +22,7 @@ inputs:
     required: false
 runs:
   using: 'docker'
-  image: docker://ghcr.io/gomisha/github-sync:v2.3.3
+  image: docker://ghcr.io/repo-sync/github-sync:v2.3.3
   env:
     GITHUB_TOKEN: ${{ inputs.github_token }}
     SYNC_TAGS: ${{ inputs.sync_tags }}

--- a/action.yml
+++ b/action.yml
@@ -22,7 +22,7 @@ inputs:
     required: false
 runs:
   using: 'docker'
-  image: docker://ghcr.io/gomisha/github-sync:v2.3.2
+  image: docker://ghcr.io/gomisha/github-sync:v2.3.3
   env:
     GITHUB_TOKEN: ${{ inputs.github_token }}
     SYNC_TAGS: ${{ inputs.sync_tags }}

--- a/github-sync.sh
+++ b/github-sync.sh
@@ -38,8 +38,9 @@ echo "Fetching tmp_upstream"
 git fetch tmp_upstream --quiet
 git remote --verbose
 
-echo "Pushing changings from tmp_upstream to origin"
-git push origin "refs/remotes/tmp_upstream/${BRANCH_MAPPING%%:*}:refs/heads/${BRANCH_MAPPING#*:}" --force
+echo "Pushing changes (not forcing) from tmp_upstream to origin"
+#git push origin "refs/remotes/tmp_upstream/${BRANCH_MAPPING%%:*}:refs/heads/${BRANCH_MAPPING#*:}" --force
+git push origin "refs/remotes/tmp_upstream/${BRANCH_MAPPING%%:*}:refs/heads/${BRANCH_MAPPING#*:}"
 
 if [[ "$SYNC_TAGS" = true ]]; then
   echo "Force syncing all tags"


### PR DESCRIPTION
This PR adds the ability to not use `--force` when doing a `git push` from the upstream repo to the current repo.