### PR TITLE
sync remote repos outside a workflow ctx

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -1,6 +1,6 @@
 name: GitHub Repo Sync
 author: Wei He <github@weispot.com>
-description: ⤵️ Sync current repository with remote
+description: ⤵️ Sync two repositories using GitHub Actions
 branding:
   icon: 'git-branch'
   color: 'gray-dark'
@@ -14,9 +14,24 @@ inputs:
   destination_branch:
     description: Branch name to sync to in this repo
     required: true
+  source_host:
+    description: Hostname of the source repo if different from github.com. If set, the source_repo must be repo slug.
+    required: false
+  destination_host:
+    description: Hostname of the destination repo if different from github.com
+    required: false
+  destination_repo:
+    description: Git repo slug. If not provided, the source_repo will be used.
+    required: false
+  destination_user:
+    description: GitHub username for pushing to the destination repo. If not provided, the default GITHUB_ACTOR will be used.
+    required: false
+  destination_token:
+    description: GitHub token secret for pushing to the destination repo. If not provided, the default GITHUB_TOKEN will be used.
+    required: false
   github_token:
-    description: GitHub token secret
-    required: true
+    description: GitHub token secret for accessing the source repo.
+    required: false
   sync_tags:
     description: Should tags also be synced
     required: false
@@ -26,6 +41,13 @@ runs:
   env:
     GITHUB_TOKEN: ${{ inputs.github_token }}
     SYNC_TAGS: ${{ inputs.sync_tags }}
+    SOURCE_HOST: ${{ inputs.source_host }}
+    SOURCE_TOKEN: ${{ inputs.github_token }}
+    SOURCE_USER: ${{ github.actor }}
+    DESTINATION_HOST: ${{ inputs.destination_host }}
+    DESTINATION_USER: ${{ inputs.destination_user }}
+    DESTINATION_TOKEN: ${{ inputs.destination_token }}
+    DESTINATION_REPO: ${{ inputs.destination_repo }}
   args:
     - ${{ inputs.source_repo }}
     - ${{ inputs.source_branch }}:${{ inputs.destination_branch }}

--- a/github-sync.sh
+++ b/github-sync.sh
@@ -2,24 +2,30 @@
 
 set -e
 
+# It's not recommended to use DEBUG=1 in production environments as it will leak your credentials.
+if [ -n "$DEBUG" ]; then
+  set -x
+fi
+
 UPSTREAM_REPO=$1
 BRANCH_MAPPING=$2
 
-if [[ -z "$UPSTREAM_REPO" ]]; then
+if [ -z "$UPSTREAM_REPO" ]; then
   echo "Missing \$UPSTREAM_REPO"
   exit 1
 fi
 
-if [[ -z "$BRANCH_MAPPING" ]]; then
+if [ -z "$BRANCH_MAPPING" ]; then
   echo "Missing \$SOURCE_BRANCH:\$DESTINATION_BRANCH"
   exit 1
 fi
 
-if ! echo $UPSTREAM_REPO | grep -Eq ':|@|\.git\/?$'
+if ! echo "$UPSTREAM_REPO" | grep -Eq ':|@|\.git/?$'
 then
-  echo "UPSTREAM_REPO does not seem to be a valid git URI, assuming it's a GitHub repo"
+  echo "UPSTREAM_REPO does not seem to be a valid git URI, assuming it's a GitHub repo slug"
   echo "Originally: $UPSTREAM_REPO"
-  UPSTREAM_REPO="https://github.com/${UPSTREAM_REPO}.git"
+  _src_hostname=${SOURCE_HOST:-"github.com"}
+  UPSTREAM_REPO="https://${_src_hostname}/${UPSTREAM_REPO}.git"
   echo "Now: $UPSTREAM_REPO"
 fi
 
@@ -28,11 +34,35 @@ echo "BRANCHES=$BRANCH_MAPPING"
 
 git config --unset-all http."https://github.com/".extraheader || :
 
-echo "Resetting origin to: https://$GITHUB_ACTOR:$GITHUB_TOKEN@github.com/$GITHUB_REPOSITORY"
-git remote set-url origin "https://$GITHUB_ACTOR:$GITHUB_TOKEN@github.com/$GITHUB_REPOSITORY"
+_hostname=${DESTINATION_HOST:-"github.com"}
+_user=${DESTINATION_USER:-$GITHUB_ACTOR}
+_token=${DESTINATION_TOKEN:-$GITHUB_TOKEN}
+_repo=${DESTINATION_REPO:-$GITHUB_REPOSITORY}
+
+if [ -z "$_user" ]; then
+  echo "Missing \$DESTINATION_USER or \$GITHUB_ACTOR"
+  exit 1
+fi
+
+if [ -z "$_token" ]; then
+  echo "Missing \$DESTINATION_TOKEN or \$GITHUB_TOKEN"
+  exit 1
+fi
+
+if [ -z "$_repo" ]; then
+  echo "Missing \$DESTINATION_REPO or \$GITHUB_REPOSITORY"
+  exit 1
+fi
+
+echo "Resetting origin to: https://$_user:***@$_hostname/$_repo"
+git remote set-url origin "https://$_user:$_token@$_hostname/$_repo"
 
 echo "Adding tmp_upstream $UPSTREAM_REPO"
-git remote add tmp_upstream "$UPSTREAM_REPO"
+if [ -n "${SOURCE_USER}" ] && [ -n "${SOURCE_TOKEN}" ]; then
+  git remote add tmp_upstream "https://${SOURCE_USER}:${SOURCE_TOKEN}@${UPSTREAM_REPO#https://}"
+else
+  git remote add tmp_upstream "$UPSTREAM_REPO"
+fi
 
 echo "Fetching tmp_upstream"
 git fetch tmp_upstream --quiet
@@ -41,9 +71,9 @@ git remote --verbose
 echo "Pushing changings from tmp_upstream to origin"
 git push origin "refs/remotes/tmp_upstream/${BRANCH_MAPPING%%:*}:refs/heads/${BRANCH_MAPPING#*:}" --force
 
-if [[ "$SYNC_TAGS" = true ]]; then
+if [ "$SYNC_TAGS" = true ]; then
   echo "Force syncing all tags"
-  git tag -d $(git tag -l) > /dev/null
+  git tag -d "$(git tag -l)" > /dev/null
   git fetch tmp_upstream --tags --quiet
   git push origin --tags --force
 fi


### PR DESCRIPTION
* add a bunch of new inputs into the action to allow a remote repo/host to be used as the upstream or destination of the sync.
* the new API surface on the action isn't the best but should be compatible with the existing usage (relying on running the workflow on the source repo and read in the builtin env vars from GitHub Actions)

related: #114

I have only tested this on a local setup and it seems to work well enough both with the existing inputs and the new ones. It could use some more iteration. See logs:


## Using GitHub Actions env vars (simulating a workflow run)
```bash
$ DEBUG=1 GITHUB_REPOSITORY=coopernetes/test-repo-sync GITHUB_ACTOR=coopernetes GITHUB_TOKEN="github_pat_token" SYNC_TAGS=true ../github-sync/github-sync.sh "https://github.com/coopernetes/test-repo" "main:main"
+ UPSTREAM_REPO=https://github.com/coopernetes/test-repo
+ BRANCH_MAPPING=main:main
+ '[' -z https://github.com/coopernetes/test-repo ']'
+ '[' -z main:main ']'
+ echo https://github.com/coopernetes/test-repo
+ grep -Eq ':|@|\.git/?$'
+ echo UPSTREAM_REPO=https://github.com/coopernetes/test-repo
UPSTREAM_REPO=https://github.com/coopernetes/test-repo
+ echo BRANCHES=main:main
BRANCHES=main:main
+ git config --unset-all http.https://github.com/.extraheader
+ :
+ _hostname=github.com
+ _user=coopernetes
+ _token=github_pat_token
+ _repo=coopernetes/test-repo-sync
+ '[' -z coopernetes ']'
+ '[' -z github_pat_token ']'
+ '[' -z coopernetes/test-repo-sync ']'
+ echo 'Resetting origin to: https://coopernetes:***@github.com/coopernetes/test-repo-sync'
Resetting origin to: https://coopernetes:***@github.com/coopernetes/test-repo-sync
+ git remote set-url origin https://coopernetes:github_pat_token@github.com/coopernetes/test-repo-sync
+ echo 'Adding tmp_upstream https://github.com/coopernetes/test-repo'
Adding tmp_upstream https://github.com/coopernetes/test-repo
+ '[' -n '' ']'
+ git remote add tmp_upstream https://github.com/coopernetes/test-repo
+ echo 'Fetching tmp_upstream'
Fetching tmp_upstream
+ git fetch tmp_upstream --quiet
+ git remote --verbose
origin	https://coopernetes:github_pat_token@github.com/coopernetes/test-repo-sync (fetch)
origin	https://coopernetes:github_pat_token@github.com/coopernetes/test-repo-sync (push)
tmp_upstream	https://github.com/coopernetes/test-repo (fetch)
tmp_upstream	https://github.com/coopernetes/test-repo (push)
+ echo 'Pushing changings from tmp_upstream to origin'
Pushing changings from tmp_upstream to origin
+ git push origin refs/remotes/tmp_upstream/main:refs/heads/main --force
Enumerating objects: 3, done.
Counting objects: 100% (3/3), done.
Writing objects: 100% (3/3), 907 bytes | 907.00 KiB/s, done.
Total 3 (delta 0), reused 0 (delta 0), pack-reused 0
To https://github.com/coopernetes/test-repo-sync
 + b6b6257...aad2d2c tmp_upstream/main -> main (forced update)
+ '[' true = true ']'
+ echo 'Force syncing all tags'
Force syncing all tags
++ git tag -l
+ git tag -d bar-tag
+ git fetch tmp_upstream --tags --quiet
+ git push origin --tags --force
Everything up-to-date
+ echo 'Removing tmp_upstream'
Removing tmp_upstream
+ git remote rm tmp_upstream
+ git remote --verbose
origin	https://coopernetes:github_pat_token@github.com/coopernetes/test-repo-sync (fetch)
origin	https://coopernetes:github_pat_token@github.com/coopernetes/test-repo-sync (push)
```

## Sync from github.com to gitlab.com
```bash
$ DEBUG=1 DESTINATION_HOST=gitlab.com DESTINATION_REPO=tomcooperca/test-repo DESTINATION_TOKEN=$(cat ~/.gitlab-token) DESTINATION_USER=oauth2 ../github-sync/github-sync.sh "https://github.com/coopernetes/test-repo-sync" "main:main"
+ UPSTREAM_REPO=https://github.com/coopernetes/test-repo-sync
+ BRANCH_MAPPING=main:main
+ '[' -z https://github.com/coopernetes/test-repo-sync ']'
+ '[' -z main:main ']'
+ echo https://github.com/coopernetes/test-repo-sync
+ grep -Eq ':|@|\.git/?$'
+ echo UPSTREAM_REPO=https://github.com/coopernetes/test-repo-sync
UPSTREAM_REPO=https://github.com/coopernetes/test-repo-sync
+ echo BRANCHES=main:main
BRANCHES=main:main
+ git config --unset-all http.https://github.com/.extraheader
+ :
+ _hostname=gitlab.com
+ _user=oauth2
+ _token=glpat-token
+ _repo=tomcooperca/test-repo
+ '[' -z oauth2 ']'
+ '[' -z glpat-token ']'
+ '[' -z tomcooperca/test-repo ']'
+ echo 'Resetting origin to: https://oauth2:***@gitlab.com/tomcooperca/test-repo'
Resetting origin to: https://oauth2:***@gitlab.com/tomcooperca/test-repo
+ git remote set-url origin https://oauth2:glpat-token@gitlab.com/tomcooperca/test-repo
+ echo 'Adding tmp_upstream https://github.com/coopernetes/test-repo-sync'
Adding tmp_upstream https://github.com/coopernetes/test-repo-sync
+ '[' -n '' ']'
+ git remote add tmp_upstream https://github.com/coopernetes/test-repo-sync
+ echo 'Fetching tmp_upstream'
Fetching tmp_upstream
+ git fetch tmp_upstream --quiet
+ git remote --verbose
origin	https://oauth2:glpat-token@gitlab.com/tomcooperca/test-repo (fetch)
origin	https://oauth2:glpat-token@gitlab.com/tomcooperca/test-repo (push)
tmp_upstream	https://github.com/coopernetes/test-repo-sync (fetch)
tmp_upstream	https://github.com/coopernetes/test-repo-sync (push)
+ echo 'Pushing changings from tmp_upstream to origin'
Pushing changings from tmp_upstream to origin
+ git push origin refs/remotes/tmp_upstream/main:refs/heads/main --force
warning: redirecting to https://gitlab.com/tomcooperca/test-repo.git/
Enumerating objects: 3, done.
Counting objects: 100% (3/3), done.
Writing objects: 100% (3/3), 617 bytes | 617.00 KiB/s, done.
Total 3 (delta 0), reused 3 (delta 0), pack-reused 0
To https://gitlab.com/tomcooperca/test-repo
 + 9125584...b6b6257 tmp_upstream/main -> main (forced update)
+ '[' '' = true ']'
+ echo 'Removing tmp_upstream'
Removing tmp_upstream
+ git remote rm tmp_upstream
+ git remote --verbose
origin	https://oauth2:glpat-token@gitlab.com/tomcooperca/test-repo (fetch)
origin	https://oauth2:glpat-token@gitlab.com/tomcooperca/test-repo (push)
```

## Sync tags on remote
```bash
$ DEBUG=1 DESTINATION_HOST=gitlab.com DESTINATION_REPO=tomcooperca/test-repo DESTINATION_TOKEN=$(cat ~/.gitlab-token) DESTINATION_USER=oauth2 SYNC_TAGS=true ../github-sync/github-sync.sh "https://github.com/coopernetes/test-repo-sync" "main:main"
+ UPSTREAM_REPO=https://github.com/coopernetes/test-repo-sync
+ BRANCH_MAPPING=main:main
+ '[' -z https://github.com/coopernetes/test-repo-sync ']'
+ '[' -z main:main ']'
+ echo https://github.com/coopernetes/test-repo-sync
+ grep -Eq ':|@|\.git/?$'
+ echo UPSTREAM_REPO=https://github.com/coopernetes/test-repo-sync
UPSTREAM_REPO=https://github.com/coopernetes/test-repo-sync
+ echo BRANCHES=main:main
BRANCHES=main:main
+ git config --unset-all http.https://github.com/.extraheader
+ :
+ _hostname=gitlab.com
+ _user=oauth2
+ _token=glpat-token
+ _repo=tomcooperca/test-repo
+ '[' -z oauth2 ']'
+ '[' -z glpat-token ']'
+ '[' -z tomcooperca/test-repo ']'
+ echo 'Resetting origin to: https://oauth2:***@gitlab.com/tomcooperca/test-repo'
Resetting origin to: https://oauth2:***@gitlab.com/tomcooperca/test-repo
+ git remote set-url origin https://oauth2:glpat-token@gitlab.com/tomcooperca/test-repo
+ echo 'Adding tmp_upstream https://github.com/coopernetes/test-repo-sync'
Adding tmp_upstream https://github.com/coopernetes/test-repo-sync
+ '[' -n '' ']'
+ git remote add tmp_upstream https://github.com/coopernetes/test-repo-sync
+ echo 'Fetching tmp_upstream'
Fetching tmp_upstream
+ git fetch tmp_upstream --quiet
+ git remote --verbose
origin	https://oauth2:glpat-token@gitlab.com/tomcooperca/test-repo (fetch)
origin	https://oauth2:glpat-token@gitlab.com/tomcooperca/test-repo (push)
tmp_upstream	https://github.com/coopernetes/test-repo-sync (fetch)
tmp_upstream	https://github.com/coopernetes/test-repo-sync (push)
+ echo 'Pushing changings from tmp_upstream to origin'
Pushing changings from tmp_upstream to origin
+ git push origin refs/remotes/tmp_upstream/main:refs/heads/main --force
warning: redirecting to https://gitlab.com/tomcooperca/test-repo.git/
Everything up-to-date
+ '[' true = true ']'
+ echo 'Force syncing all tags'
Force syncing all tags
++ git tag -l
+ git tag -d bar-tag
+ git fetch tmp_upstream --tags --quiet
+ git push origin --tags --force
warning: redirecting to https://gitlab.com/tomcooperca/test-repo.git/
Enumerating objects: 1, done.
Counting objects: 100% (1/1), done.
Writing objects: 100% (1/1), 368 bytes | 368.00 KiB/s, done.
Total 1 (delta 0), reused 0 (delta 0), pack-reused 0
To https://gitlab.com/tomcooperca/test-repo
 * [new tag]         bar-tag -> bar-tag
+ echo 'Removing tmp_upstream'
Removing tmp_upstream
+ git remote rm tmp_upstream
+ git remote --verbose
origin	https://oauth2:glpat-token@gitlab.com/tomcooperca/test-repo (fetch)
origin	https://oauth2:glpat-token@gitlab.com/tomcooperca/test-repo (push)
```