### PR TITLE
Use auto generated GITHUB_TOKEN instead of PAT

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,9 @@ Create a personal access token and add to repository's secret as `PAT`
 ```
 # File: .github/workflows/repo-sync.yml
 
+permissions:
+  contents: write
+
 on:
   schedule:
   - cron:  "*/15 * * * *"
@@ -40,7 +43,7 @@ jobs:
         source_repo: ""
         source_branch: ""
         destination_branch: ""
-        github_token: ${{ secrets.PAT }}
+        github_token: ${{ secrets.GITHUB_TOKEN }}
 ```
 If `source_repo` is private or with another provider, either (1) use an authenticated HTTPS repo clone url like `https://${access_token}@github.com/owner/repository.git` or (2) set a `SSH_PRIVATE_KEY` secret environment variable and use the SSH clone url
 

--- a/README.md
+++ b/README.md
@@ -16,8 +16,6 @@ A GitHub Action for syncing the current repository using **force push**.
 
 ## Usage
 
-Create a personal access token and add to repository's secret as `PAT`
-
 ### GitHub Actions
 ```
 # File: .github/workflows/repo-sync.yml


### PR DESCRIPTION
You don't need to use a Personal Access Token anymore.
You can use the GitHub Action automatically supplied GITHUB_TOKEN, instead.