### PR TITLE
Automatic GITHUB_TOKEN secret instead PAT

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ A GitHub Action for syncing the current repository using **force push**.
 
 ## Usage
 
-Create a personal access token and add to repository's secret as `PAT`
+Use GitHub provided unique token created automatically as GITHUB_TOKEN secret in your workflow.
 
 ### GitHub Actions
 ```
@@ -40,7 +40,7 @@ jobs:
         source_repo: ""
         source_branch: ""
         destination_branch: ""
-        github_token: ${{ secrets.PAT }}
+        github_token: ${{ secrets.GITHUB_TOKEN }}
 ```
 If `source_repo` is private or with another provider, either (1) use an authenticated HTTPS repo clone url like `https://${access_token}@github.com/owner/repository.git` or (2) set a `SSH_PRIVATE_KEY` secret environment variable and use the SSH clone url
 


### PR DESCRIPTION
Currently possible to automatically authenticate with GitHub provided token on behalf of GitHub Actions

https://docs.github.com/en/actions/security-guides/automatic-token-authentication