### PR TITLE
Feature: Include git-lfs in container to enable LFS repo syncing

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,8 +10,12 @@ LABEL \
   org.opencontainers.image.authors="Wei He <github@weispot.com>" \
   maintainer="Wei He <github@weispot.com>"
 
-RUN apk add --no-cache git openssh-client && \
-  echo "StrictHostKeyChecking no" >> /etc/ssh/ssh_config
+RUN apk add --no-cache \
+        git \
+        git-lfs \
+        openssh-client
+
+RUN echo "StrictHostKeyChecking no" >> /etc/ssh/ssh_config
 
 ADD *.sh /
 


### PR DESCRIPTION
When cloning a git repository that has lfs enabled, the following error is thrown:
```
This repository is configured for Git LFS but 'git-lfs' was not found on your path. If you no longer wish to use Git LFS, remove this hook by deleting the 'pre-push' file in the hooks directory (set by 'core.hookspath'; usually '.git/hooks').
```

This should add the git-lfs binary and thus enable syncing git repos that have LFS enabled.