### PR TITLE
Add deprecation notice; archive this repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,11 @@
 # GitHub Sync
+
+> ## ⚠️ Unmaintained
+>
+> This repository is being archived and is no longer maintained.
+>
+> Existing references pinned to a tag or commit SHA continue to function only as long as the `ghcr.io/repo-sync/github-sync:v2.3.0` container image (referenced from `action.yml`) remains available. No further updates, bug fixes, or security patches will be made. We recommend migrating to an alternative or vendoring the script into your own workflow.
+
 <!-- ALL-CONTRIBUTORS-BADGE:START - Do not remove or modify this section -->
 [![All Contributors](https://img.shields.io/badge/all_contributors-6-orange.svg?style=flat-square)](#contributors-)
 <!-- ALL-CONTRIBUTORS-BADGE:END -->


### PR DESCRIPTION
_Posted on behalf of @heiskr by GitHub Copilot CLI._

This repository is being archived. Adds an ⚠️ Unmaintained section to the top of the README so anyone landing here knows the action is no longer maintained.

After this merges:
- All open issues and PRs will be closed with a brief winding-down comment.
- The repository will be archived (`gh repo archive repo-sync/github-sync`).

Pinned-SHA and tag references will continue to work as long as the `ghcr.io/repo-sync/github-sync:v2.3.0` container image stays published in GHCR.

The GitHub Docs team (the primary user of this action) has already vendored an equivalent inline shell step into its own `Repo Sync` workflow — see github/docs-internal#61447.